### PR TITLE
Chore/proposals voting

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,5 @@
+# Sample ENV 
+
+# API_VERSION=0 # currently only supports versions documented in /public/docs/api
+PUBLIC_CLERK_PUBLISHABLE_KEY=​pk_test_ZW5vcm1vdXMtYnVnLTMxLmNsZXJrLmFjY291bnRzLmRldiQ​
+PUBLIC_VOTE_SERVICE_HOST=http://localhost:3000

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable prefer-destructuring */
+
 export const PUBLIC_CLERK_PUBLISHABLE_KEY =
   'pk_test_ZW5vcm1vdXMtYnVnLTMxLmNsZXJrLmFjY291bnRzLmRldiQ';
+export const PUBLIC_VOTE_SERVICE_HOST = import.meta.env
+  .PUBLIC_VOTE_SERVICE_HOST;

--- a/src/features/ui/LoadingSpinner.tsx
+++ b/src/features/ui/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+export function LoadingSpinner() {
+  return (
+    <div className="flex space-x-2 justify-center items-center">
+      <span className="sr-only">Loading...</span>
+      <div className="h-4 w-4 bg-black rounded-full animate-bounce [animation-delay:-0.3s]" />
+      <div className="h-4 w-4 bg-black rounded-full animate-bounce [animation-delay:-0.15s]" />
+      <div className="h-4 w-4 bg-black rounded-full animate-bounce" />
+    </div>
+  );
+}

--- a/src/features/voting/ProposalCard.tsx
+++ b/src/features/voting/ProposalCard.tsx
@@ -25,7 +25,7 @@ export type ProposalCardProps = DatabaseObject & Proposal & ProposalState;
 
 export default function ProposalCard(props: ProposalCardProps) {
   const [vote, setVote] = useState(props.userVote);
-  const [prevVote, setPrevVote] = useState(props.userVote);
+  const [previousVote, setPreviousVote] = useState(props.userVote);
 
   const proposedDate = useMemo(
     () =>
@@ -83,10 +83,10 @@ export default function ProposalCard(props: ProposalCardProps) {
         queries: { recordId: props.id },
       })
       .then(() => {
-        setPrevVote(newVote);
+        setPreviousVote(newVote);
       })
       .catch(() => {
-        setVote(prevVote);
+        setVote(previousVote);
         toast.error('Unable to cast vote. Please try again.');
       });
   });

--- a/src/features/voting/ProposalInterestVote.tsx
+++ b/src/features/voting/ProposalInterestVote.tsx
@@ -33,10 +33,13 @@ export default function ProposalInterestVote(props: ProposalInterestVoteProps) {
     <RadioGroup
       aria-label="Vote"
       className="flex flex-col md:flex-row md:items-center gap-2"
-      value={props.vote?.value}
+      value={props.vote?.value.toString()}
       disabled={props.disabled}
-      onValueChange={(value: Vote['value']) =>
-        props.onVoteChange({ ...(props.vote ?? {}), value })
+      onValueChange={(value: string) =>
+        props.onVoteChange({
+          ...(props.vote ?? {}),
+          value: parseInt(value, 10),
+        })
       }
     >
       {voteOptions.map(({ label, value, id }) => (

--- a/src/features/voting/ProposalLikeButtons.tsx
+++ b/src/features/voting/ProposalLikeButtons.tsx
@@ -4,7 +4,7 @@ import type { Vote } from '../../sdk.ts';
 
 type ProposalLikeButtonsProps = {
   onVoteValueChange: (vote: Vote['value']) => void;
-  voteValue: string | undefined;
+  voteValue: number | undefined;
   numberUpvotes: number | string;
   numberDownvotes: number | string;
   disabled?: boolean;
@@ -18,12 +18,12 @@ export default function ProposalLikeButtons({
   voteValue,
 }: ProposalLikeButtonsProps) {
   const handleLikeVote = (type: 'up' | 'down') => {
-    let currentVoteValue = voteValue ? parseInt(voteValue, 10) : 0;
+    let currentVoteValue = voteValue ?? 0;
 
     if (type === 'up') currentVoteValue = Math.min(2, currentVoteValue + 1);
     else currentVoteValue = Math.max(-2, currentVoteValue - 1);
 
-    onVoteValueChange(currentVoteValue.toString() as Vote['value']);
+    onVoteValueChange(currentVoteValue as Vote['value']);
   };
 
   return (

--- a/src/features/voting/ProposalList.tsx
+++ b/src/features/voting/ProposalList.tsx
@@ -5,12 +5,13 @@ import ProposalFormButton from './ProposalFormButton.tsx';
 import ProposalCard, { type ProposalCardProps } from './ProposalCard.tsx';
 import { Button } from '../ui/button.tsx';
 import { sdk, type Paginated } from '../../sdk.ts';
+import { LoadingSpinner } from '../ui/LoadingSpinner.tsx';
 
 // This component auto-loads proposals on scroll, so we hard-code a static limit
 const limit = 10;
 
 export function ProposalList() {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [cursor, setCursor] = useState<Paginated['cursor']>();
   const [proposals, setProposals] = useState<ProposalCardProps[]>([]);
 
@@ -41,24 +42,34 @@ export function ProposalList() {
     <div>
       <ul className="flex flex-col" id="proposal-list">
         {proposals.map((proposal) => (
-          <li key={`${proposal.summary}`} className="mb-2">
+          <li key={`${proposal.id}`} className="mb-2">
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}
             <ProposalCard {...proposal} />
           </li>
         ))}
-        {loading || proposals.length ?
+
+        {loading && (
+          <div className="flex justify-center p-5 text-black">
+            <LoadingSpinner />
+          </div>
+        )}
+
+        {!loading && cursor && (
           <div className="flex justify-center p-5 text-black">
             <Button onClick={onClick} busy={loading} variant="secondary">
               Load More
             </Button>
           </div>
-        : <li>
+        )}
+
+        {!loading && proposals.length === 0 && (
+          <li>
             <div className="text-center p-2">
               <h2 className="font-bold text-xl mb-2">No proposals found</h2>
               <ProposalFormButton />
             </div>
           </li>
-        }
+        )}
       </ul>
     </div>
   );

--- a/src/features/voting/ProposalList.tsx
+++ b/src/features/voting/ProposalList.tsx
@@ -18,34 +18,35 @@ export function ProposalList() {
   const [proposals, setProposals] = useState<ProposalCardProps[]>([]);
 
   const loadProposals = useCallback(
-    (pagination: Paginated) => {
-      void session?.getToken().then((token) => {
-        setLoading(true);
-        sdk
-          .listProposals({
-            queries: { pagination },
-            headers: { authorization: `Bearer ${token}` },
-          })
-          .then((result) => {
-            setCursor(result.cursor);
-            setProposals((previous) => [...previous, ...result.proposals]);
-          })
-          .catch(console.error)
-          .finally(() => setLoading(false));
-      });
+    async (pagination: Paginated) => {
+      const token = await session?.getToken();
+
+      setLoading(true);
+      sdk
+        .listProposals({
+          queries: { pagination },
+          headers: token ? { authorization: `Bearer ${token}` } : {},
+        })
+        .then((result) => {
+          setCursor(result.cursor);
+          setProposals((previous) => [...previous, ...result.proposals]);
+        })
+        .catch(toast.error)
+        .finally(() => setLoading(false));
     },
     [session],
   );
 
   useEffect(() => {
-    // Load initial proposals
-    loadProposals({ limit });
-  }, [loadProposals]);
+    if (session !== undefined) {
+      void loadProposals({ limit });
+    }
+  }, [session, loadProposals]);
 
   const onClick = useCallback(() => {
     if (loading) return;
     if (!cursor) return;
-    loadProposals({ cursor, limit });
+    void loadProposals({ cursor, limit });
   }, [loading, loadProposals, cursor]);
 
   return (

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -38,27 +38,15 @@ export type DatabaseObject = {
   created: string;
   updated: string;
 };
-export type ProposalState =
-  | {
-      authorName: string;
-      /**
-       * @enum closed
-       */
-      status: 'closed';
-      userVote?: Vote | undefined;
-      results: Array<Vote>;
-    }
-  | {
-      /**
-       * @minLength 4
-       */
-      authorName: string;
-      /**
-       * @enum open
-       */
-      status: 'open';
-      userVote?: Vote | undefined;
-    };
+export type ProposalState = {
+  authorName: string;
+  /**
+   * @enum closed
+   */
+  status: 'closed' | 'open';
+  userVote?: Vote | undefined;
+  results: Array<Vote>;
+};
 export type Vote = {
   /**
    * Ranking values: -2 (strong disinterest), -1 (slight disinterest), 0 (neutral), 1 (slight interest), 2 (strong interest)
@@ -70,7 +58,7 @@ export type Vote = {
   comment?: /**
    * @maxLength 255
    */
-  string | undefined;
+  string | null;
 };
 export type ProposalIndex = Paginated & {
   proposals: Array<Proposal & ProposalState & DatabaseObject>;
@@ -141,21 +129,14 @@ const Vote: z.ZodType<Vote> = z.object({
     .describe(
       'Ranking values: -2 (strong disinterest), -1 (slight disinterest), 0 (neutral), 1 (slight interest), 2 (strong interest)',
     ),
-  comment: z.string().max(255).optional(),
+  comment: z.string().max(255).nullable().optional(),
 });
-const ProposalState: z.ZodType<ProposalState> = z.union([
-  z.object({
-    authorName: z.string(),
-    status: z.literal('closed'),
-    userVote: Vote.optional(),
-    results: z.array(Vote),
-  }),
-  z.object({
-    authorName: z.string().min(4),
-    status: z.literal('open'),
-    userVote: Vote.optional(),
-  }),
-]);
+const ProposalState: z.ZodType<ProposalState> = z.object({
+  authorName: z.string(),
+  status: z.union([z.literal('closed'), z.literal('open')]),
+  userVote: Vote.optional(),
+  results: z.array(Vote),
+});
 const ProposalIndex: z.ZodType<ProposalIndex> = Paginated.and(
   z.object({
     proposals: z.array(Proposal.and(ProposalState).and(DatabaseObject)),
@@ -491,7 +472,7 @@ const endpoints = makeApi([
             .describe(
               'Ranking values: -2 (strong disinterest), -1 (slight disinterest), 0 (neutral), 1 (slight interest), 2 (strong interest)',
             ),
-          comment: z.string().max(255).optional(),
+          comment: z.string().max(255).nullable().optional(),
         }),
       },
       {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -63,9 +63,10 @@ export type Vote = {
   /**
    * Ranking values: -2 (strong disinterest), -1 (slight disinterest), 0 (neutral), 1 (slight interest), 2 (strong interest)
    *
-   * @enum -2, -1, 0, 1, 2
+   * @min -2
+   * @max 2
    */
-  value: '-2' | '-1' | '0' | '1' | '2';
+  value: number;
   comment?: /**
    * @maxLength 255
    */
@@ -134,7 +135,9 @@ const Proposal: z.ZodType<Proposal> = z.object({
 });
 const Vote: z.ZodType<Vote> = z.object({
   value: z
-    .enum(['-2', '-1', '0', '1', '2'])
+    .number()
+    .min(-2)
+    .max(2)
     .describe(
       'Ranking values: -2 (strong disinterest), -1 (slight disinterest), 0 (neutral), 1 (slight interest), 2 (strong interest)',
     ),
@@ -473,7 +476,7 @@ const endpoints = makeApi([
   },
   {
     method: 'post',
-    path: '/proposals/vote',
+    path: '/proposals/votes',
     alias: 'submitVote',
     requestFormat: 'json',
     parameters: [
@@ -482,7 +485,9 @@ const endpoints = makeApi([
         type: 'Body',
         schema: z.object({
           value: z
-            .enum(['-2', '-1', '0', '1', '2'])
+            .number()
+            .min(-2)
+            .max(2)
             .describe(
               'Ranking values: -2 (strong disinterest), -1 (slight disinterest), 0 (neutral), 1 (slight interest), 2 (strong interest)',
             ),
@@ -514,7 +519,7 @@ const endpoints = makeApi([
   },
   {
     method: 'delete',
-    path: '/proposals/vote',
+    path: '/proposals/votes',
     alias: 'deleteVote',
     requestFormat: 'json',
     parameters: [

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,5 +1,6 @@
 import { makeApi, Zodios, type ZodiosOptions } from '@zodios/core';
 import { z } from 'zod';
+import { PUBLIC_VOTE_SERVICE_HOST } from './constants';
 
 export type DraftIndex = Paginated & {
   drafts: Array<Draft & DatabaseObject>;
@@ -547,7 +548,7 @@ const endpoints = makeApi([
   },
 ]);
 
-export const sdk = new Zodios('https://vote.tulsawebdevs.org', endpoints);
+export const sdk = new Zodios(PUBLIC_VOTE_SERVICE_HOST, endpoints);
 
 export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
   return new Zodios(baseUrl, endpoints, options);


### PR DESCRIPTION
## Description

This PR is to sync with the updates in the latest PR on the backend: https://github.com/tulsawebdevs/services-voting/pull/56

What was updated:
- Schemas to match the backend for casting votes
- Updated the "load more" to disappear when no more proposals are available
- A user's votes now display for proposals they voted on
- Fixed reference to the correct `/votes` endpoint
- Reverts vote if an error occurs