### PR TITLE
fix: swap like button positions

### DIFF
--- a/src/features/voting/ProposalLikeButtons.tsx
+++ b/src/features/voting/ProposalLikeButtons.tsx
@@ -31,21 +31,21 @@ export default function ProposalLikeButtons({
       <Button
         size="sm"
         variant="outline"
-        onClick={() => handleLikeVote('up')}
-        disabled={disabled}
-      >
-        <ThumbsUpIcon className="w-5 h-5 text-green-500 mr-1" />
-        <span className="text-green-500 font-medium">{numberUpvotes}</span>
-      </Button>
-
-      <Button
-        size="sm"
-        variant="outline"
         onClick={() => handleLikeVote('down')}
         disabled={disabled}
       >
         <ThumbsDownIcon className="w-5 h-5 text-red-500 mr-1" />
         <span className="text-red-500 font-medium">{numberDownvotes}</span>
+      </Button>
+
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => handleLikeVote('up')}
+        disabled={disabled}
+      >
+        <ThumbsUpIcon className="w-5 h-5 text-green-500 mr-1" />
+        <span className="text-green-500 font-medium">{numberUpvotes}</span>
       </Button>
     </div>
   );


### PR DESCRIPTION
# Pull Request Template

- Fixes: <!-- #(issue) -->
- Closes: <!-- #(issue) -->

## Description

Swap positions of thumbs up buttons to match the order of the dislikes radio options from left-to-right.

## Screenshots (if appropriate):

Please review and suggest any further insights, improvements, or modifications needed.
